### PR TITLE
[FEAT] REST API 반환 데이터 타입 및 커스텀 예외 타입 정의

### DIFF
--- a/src/main/java/tf/tailfriend/global/exception/CustomException.java
+++ b/src/main/java/tf/tailfriend/global/exception/CustomException.java
@@ -1,0 +1,8 @@
+package tf.tailfriend.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class CustomException extends RuntimeException {
+    abstract public HttpStatus getStatus();
+    abstract public String getMessage();
+}

--- a/src/main/java/tf/tailfriend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/tf/tailfriend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package tf.tailfriend.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import tf.tailfriend.global.response.CustomResponse;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> globalExceptionHandler(CustomException e) {
+        log.warn("{} Occurred: {}", e.getClass().getSimpleName(), e.getMessage());
+
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(new CustomResponse(e.getMessage(), null));
+    }
+}

--- a/src/main/java/tf/tailfriend/global/response/CustomResponse.java
+++ b/src/main/java/tf/tailfriend/global/response/CustomResponse.java
@@ -1,0 +1,14 @@
+package tf.tailfriend.global.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomResponse {
+    private String message;
+    private Object data;
+}


### PR DESCRIPTION
## 📢 작업 내용
- [x] ResponseEntity의 Body부분에 들어갈 데이터 타입 정의
- [x] 커스텀 예외 타입 정의

## 🔎 변경 사항
해당 PR에서 변경된 내용에 대한 간략한 설명을 적어주세요.

## 💡 추가 설명
ResponseEntity의 body부분에 들어갈 데이터를 CustomResponse로 정의했습니다.
CustomException을 상속 받는 예외를 발생시키면 자동으로 ResponseEntity를 생성하고 반환시킵니다.

## ⛓️ 관련 이슈
Closes #24 
