### PR TITLE
[FEAT] 결제내역 리스트 출력기능 구현

### DIFF
--- a/src/main/java/tf/tailfriend/facility/entity/Facility.java
+++ b/src/main/java/tf/tailfriend/facility/entity/Facility.java
@@ -18,16 +18,10 @@ public class Facility {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "facility_type_id", nullable = false)
-    private FacilityType facilityType;
+    private FacilityType facilityTypeId;
 
     @Column(nullable = false)
     private String name;
-
-    @Column(name = "open_time")
-    private LocalTime openTime;
-
-    @Column(name = "close_time")
-    private LocalTime closeTime;
 
     @Column(length = 50)
     private String tel;
@@ -37,6 +31,9 @@ public class Facility {
 
     @Column(name = "star_point", nullable = false)
     private Double starPoint = 0.0;
+
+    @Column(name= "review_count", nullable = false)
+    private Integer reviewCount = 0;
 
     @Column(nullable = false)
     private String address;

--- a/src/main/java/tf/tailfriend/reserve/controller/PaymentController.java
+++ b/src/main/java/tf/tailfriend/reserve/controller/PaymentController.java
@@ -1,0 +1,61 @@
+package tf.tailfriend.reserve.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import tf.tailfriend.reserve.dto.ListResponseDto;
+import tf.tailfriend.reserve.dto.PaymentInfoResponseDto;
+import tf.tailfriend.reserve.dto.PaymentListRequestDto;
+import tf.tailfriend.reserve.service.PaymentService;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/payment")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @RequestMapping("/get")
+    public ResponseEntity<ListResponseDto<PaymentInfoResponseDto>> getPayments(
+            @RequestParam("id") int userId,
+            @RequestParam("fid") int facilityTypeId,
+            @RequestParam(value = "startDate", required = false) String startDate,
+            @RequestParam(value = "endDate", required = false) String endDate,
+            @RequestParam("page") int page,
+            @RequestParam("size") int size) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        LocalDateTime parsedStartDate = null;
+        LocalDateTime parsedEndDate = null;
+
+        try {
+            if (startDate != null && !startDate.isEmpty()) {
+                parsedStartDate = LocalDateTime.parse(startDate, formatter);
+            }
+            if (endDate != null && !endDate.isEmpty()) {
+                parsedEndDate = LocalDateTime.parse(endDate, formatter);
+            }
+        } catch (Exception e) {
+            System.out.println("예외 발생");
+            return ResponseEntity.badRequest().body(null); // 예외 처리
+        }
+
+        PaymentListRequestDto requestDto = PaymentListRequestDto.builder()
+                .userId(userId)
+                .facilityTypeId(facilityTypeId)
+                .startDate(parsedStartDate)
+                .endDate(parsedEndDate)
+                .page(page)
+                .size(size)
+                .build();
+
+        ListResponseDto<PaymentInfoResponseDto> list = paymentService.getList(requestDto);
+        return ResponseEntity.ok(list);
+    }
+}

--- a/src/main/java/tf/tailfriend/reserve/controller/ReserveController.java
+++ b/src/main/java/tf/tailfriend/reserve/controller/ReserveController.java
@@ -1,4 +1,10 @@
 package tf.tailfriend.reserve.controller;
 
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reserve")
 public class ReserveController {
+
 }

--- a/src/main/java/tf/tailfriend/reserve/dto/ListResponseDto.java
+++ b/src/main/java/tf/tailfriend/reserve/dto/ListResponseDto.java
@@ -1,0 +1,20 @@
+package tf.tailfriend.reserve.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class ListResponseDto<T> {
+
+    private List<T> data;
+    private Integer currentPage;
+    private Integer size;
+    private Integer totalPages;
+    private long totalElements;
+
+}

--- a/src/main/java/tf/tailfriend/reserve/dto/PaymentInfoResponseDto.java
+++ b/src/main/java/tf/tailfriend/reserve/dto/PaymentInfoResponseDto.java
@@ -1,0 +1,17 @@
+package tf.tailfriend.reserve.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class PaymentInfoResponseDto {
+
+    private Integer id;
+    private String name;
+    private String createdAt;
+    private Integer price;
+
+}

--- a/src/main/java/tf/tailfriend/reserve/dto/PaymentListRequestDto.java
+++ b/src/main/java/tf/tailfriend/reserve/dto/PaymentListRequestDto.java
@@ -1,0 +1,28 @@
+package tf.tailfriend.reserve.dto;
+
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+public class PaymentListRequestDto {
+
+    private Integer userId;
+    private Integer facilityTypeId;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime endDate;
+
+    @Builder.Default
+    private int page = 0;
+
+    @Builder.Default
+    private int size = 10;
+
+}

--- a/src/main/java/tf/tailfriend/reserve/repository/CustomPaymentDao.java
+++ b/src/main/java/tf/tailfriend/reserve/repository/CustomPaymentDao.java
@@ -1,0 +1,11 @@
+package tf.tailfriend.reserve.repository;
+
+import org.springframework.stereotype.Repository;
+import tf.tailfriend.reserve.dto.ListResponseDto;
+import tf.tailfriend.reserve.dto.PaymentInfoResponseDto;
+import tf.tailfriend.reserve.dto.PaymentListRequestDto;
+
+@Repository
+public interface CustomPaymentDao {
+    ListResponseDto<PaymentInfoResponseDto> findPaymentsByRequestDto(PaymentListRequestDto requestDto); // 유저 ID와 시설 ID를 기준으로 결제 내역 조회
+}

--- a/src/main/java/tf/tailfriend/reserve/repository/PaymentDao.java
+++ b/src/main/java/tf/tailfriend/reserve/repository/PaymentDao.java
@@ -1,0 +1,9 @@
+package tf.tailfriend.reserve.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import tf.tailfriend.reserve.entity.Payment;
+
+@Repository
+public interface PaymentDao extends JpaRepository<Payment, Integer>, CustomPaymentDao {
+}

--- a/src/main/java/tf/tailfriend/reserve/repository/PaymentDaoImpl.java
+++ b/src/main/java/tf/tailfriend/reserve/repository/PaymentDaoImpl.java
@@ -1,0 +1,114 @@
+package tf.tailfriend.reserve.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Repository;
+import tf.tailfriend.reserve.dto.ListResponseDto;
+import tf.tailfriend.reserve.dto.PaymentInfoResponseDto;
+import tf.tailfriend.reserve.dto.PaymentListRequestDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+public class PaymentDaoImpl implements CustomPaymentDao {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public ListResponseDto<PaymentInfoResponseDto> findPaymentsByRequestDto(PaymentListRequestDto requestDto) {
+
+        // 기본 SQL 쿼리 작성
+        StringBuilder sql = new StringBuilder("""
+            SELECT 
+                p.id,
+                f.name,
+                p.created_at,
+                p.price
+            FROM payments p
+            JOIN reserves r ON p.reserve_id = r.id
+            JOIN facilities f ON r.user_id = f.id
+            WHERE r.user_id = :userId
+              AND f.facility_type_id = :facilityTypeId
+        """);
+
+        // 날짜 필터링 추가
+        if (requestDto.getStartDate() != null) {
+            sql.append(" AND p.created_at >= :startDate");
+        }
+        if (requestDto.getEndDate() != null) {
+            sql.append(" AND p.created_at <= :endDate");
+        }
+
+        // 정렬 기준
+        sql.append(" ORDER BY p.created_at DESC");
+
+        // 쿼리 실행
+        Query query = em.createNativeQuery(sql.toString());
+        query.setParameter("userId", requestDto.getUserId());
+        query.setParameter("facilityTypeId", requestDto.getFacilityTypeId());
+
+        if (requestDto.getStartDate() != null) {
+            query.setParameter("startDate", requestDto.getStartDate());
+        }
+        if (requestDto.getEndDate() != null) {
+            query.setParameter("endDate", requestDto.getEndDate());
+        }
+
+        // 데이터 조회
+        List<Object[]> results = query.getResultList();
+
+        // DTO 변환
+        List<PaymentInfoResponseDto> dtoList = results.stream()
+                .map(row -> PaymentInfoResponseDto.builder()
+                        .id((Integer) row[0])
+                        .name((String) row[1])
+                        .createdAt(row[2].toString())  // 필요한 포맷으로 변환 가능
+                        .price((Integer) row[3])
+                        .build())
+                .collect(Collectors.toList());
+
+        // 전체 데이터 개수 조회 (페이징용)
+        String countSql = """
+            SELECT COUNT(*) 
+            FROM payments p
+            JOIN reserves r ON p.reserve_id = r.id
+            JOIN facilities f ON r.user_id = f.id
+            WHERE r.user_id = :userId
+              AND f.facility_type_id = :facilityTypeId
+        """;
+
+        if (requestDto.getStartDate() != null) {
+            countSql += " AND p.created_at >= :startDate";
+        }
+        if (requestDto.getEndDate() != null) {
+            countSql += " AND p.created_at <= :endDate";
+        }
+
+        // 전체 데이터 개수 쿼리 실행
+        Query countQuery = em.createNativeQuery(countSql);
+        countQuery.setParameter("userId", requestDto.getUserId());
+        countQuery.setParameter("facilityTypeId", requestDto.getFacilityTypeId());
+
+        if (requestDto.getStartDate() != null) {
+            countQuery.setParameter("startDate", requestDto.getStartDate());
+        }
+        if (requestDto.getEndDate() != null) {
+            countQuery.setParameter("endDate", requestDto.getEndDate());
+        }
+
+        long totalElements = ((Number) countQuery.getSingleResult()).longValue();
+        int totalPages = (int) Math.ceil((double) totalElements / requestDto.getSize());
+
+        // ListResponseDto 반환
+        return ListResponseDto.<PaymentInfoResponseDto>builder()
+                .data(dtoList)
+                .currentPage(requestDto.getPage())
+                .size(requestDto.getSize())
+                .totalPages(totalPages)
+                .totalElements(totalElements)
+                .build();
+    }
+}

--- a/src/main/java/tf/tailfriend/reserve/repository/ReserveDao.java
+++ b/src/main/java/tf/tailfriend/reserve/repository/ReserveDao.java
@@ -1,4 +1,8 @@
 package tf.tailfriend.reserve.repository;
 
-public interface ReserveDao {
+import org.springframework.data.jpa.repository.JpaRepository;
+import tf.tailfriend.reserve.entity.Reserve;
+
+public interface ReserveDao extends JpaRepository<Reserve, Integer> {
+
 }

--- a/src/main/java/tf/tailfriend/reserve/service/PaymentService.java
+++ b/src/main/java/tf/tailfriend/reserve/service/PaymentService.java
@@ -1,0 +1,22 @@
+package tf.tailfriend.reserve.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import tf.tailfriend.reserve.dto.ListResponseDto;
+import tf.tailfriend.reserve.dto.PaymentInfoResponseDto;
+import tf.tailfriend.reserve.dto.PaymentListRequestDto;
+import tf.tailfriend.reserve.repository.PaymentDao;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+     private final PaymentDao paymentDao;
+
+     public ListResponseDto<PaymentInfoResponseDto> getList(PaymentListRequestDto requestDto) {
+          System.out.println("PaymentService.getList()");
+        return paymentDao.findPaymentsByRequestDto(requestDto);
+     }
+
+
+}


### PR DESCRIPTION
## 📢 작업 내용
- [x] 결제내역 리스트 출력기능 구현

## 🔎 변경 사항
facility/entity/Facility 클래스 내의 필드명 수정 및 새 필드 추가
컬럼 수정: facilityType(DB 컬럼명: facility_type_id) => facilityTypeId
컬럼 추가: reviewCount(DB 컬럼명: review_count)

## 🚀 테스트 방법
1. Postman 프로그램 사용 http://localhost:8080/api/payment/get?id=1&fid=1&page=0&size=10 GET 요청 시 반환되는 파라미터 값 확인 완료

## 📸 스크린샷 (선택)
![스크린샷 2025-04-18 190216](https://github.com/user-attachments/assets/bc319813-22ce-4c98-b204-c00a6ae6319b)
![스크린샷 2025-04-18 191336](https://github.com/user-attachments/assets/ec15efb3-a913-4688-b5cd-bfe0533f5ad8)

## 💡 추가 설명
[Postman](https://www.postman.com/)

## ⛓️ 관련 이슈
Closes #23
