### PR TITLE
[ADD] 펫시터 검열 및 상세보기

### DIFF
--- a/src/main/java/tf/tailfriend/petsitter/controller/PetSitterController.java
+++ b/src/main/java/tf/tailfriend/petsitter/controller/PetSitterController.java
@@ -12,6 +12,9 @@ import tf.tailfriend.global.response.CustomResponse;
 import tf.tailfriend.petsitter.dto.PetSitterRequestDto;
 import tf.tailfriend.petsitter.dto.PetSitterResponseDto;
 import tf.tailfriend.petsitter.service.PetSitterService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -24,10 +27,7 @@ public class PetSitterController {
     private final PetSitterService petSitterService;
     private final ObjectMapper objectMapper;
 
-    /**
-     * 사용자가 펫시터 신청을 제출하는 API
-     * 오류 처리 및 응답 개선
-     */
+    //사용자가 펫시터 신청을 제출하는 API
     @PostMapping("/apply")
     public ResponseEntity<?> applyForPetSitter(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -72,9 +72,7 @@ public class PetSitterController {
         }
     }
 
-    /**
-     * 사용자의 펫시터 신청 상태를 조회하는 API
-     */
+    //사용자의 펫시터 신청 상태를 조회하는 API
     @GetMapping("/status")
     public ResponseEntity<?> getPetSitterStatus(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         if (userPrincipal == null) {
@@ -105,9 +103,7 @@ public class PetSitterController {
         }
     }
 
-    /**
-     * 사용자가 펫시터를 그만두는 API
-     */
+    // 사용자가 펫시터를 그만두는 API
     @PostMapping("/quit")
     public ResponseEntity<?> quitPetSitter(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         if (userPrincipal == null) {
@@ -130,6 +126,100 @@ public class PetSitterController {
             log.error("펫시터 그만두기 오류: userId={}", userPrincipal.getUserId(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new CustomResponse("펫시터 그만두기 처리 중 오류가 발생했습니다: " + e.getMessage(), null));
+        }
+    }
+
+    // 조건에 맞는 승인된 펫시터 목록을 조회하는 API
+    @GetMapping("/approved")
+    public ResponseEntity<?> getApprovedPetSitters(
+            @RequestParam(required = false) String age,
+            @RequestParam(required = false) Boolean petOwnership,
+            @RequestParam(required = false) Boolean sitterExp,
+            @RequestParam(required = false) String houseType,
+            Pageable pageable) {
+
+        try {
+            log.info("승인된 펫시터 목록 조회: age={}, petOwnership={}, sitterExp={}, houseType={}",
+                    age, petOwnership, sitterExp, houseType);
+
+            // 페이지 사이즈 기본값 설정
+            if (pageable.getPageSize() > 50) {
+                pageable = PageRequest.of(pageable.getPageNumber(), 50, pageable.getSort());
+            }
+
+            // 승인된 펫시터 중 조건에 맞는 목록 조회
+            Page<PetSitterResponseDto> results = petSitterService.findApprovedPetSittersWithCriteria(
+                    age, petOwnership, sitterExp, houseType, pageable);
+
+            log.info("승인된 펫시터 목록 조회 완료: totalElements={}", results.getTotalElements());
+
+            return ResponseEntity.ok(new CustomResponse("조회 성공", results));
+
+        } catch (Exception e) {
+            log.error("승인된 펫시터 목록 조회 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new CustomResponse("펫시터 목록 조회 중 오류가 발생했습니다: " + e.getMessage(), null));
+        }
+    }
+
+    // 펫시터 목록을 조회하는 API (상태별 필터링 가능)
+    @GetMapping("/list")
+    public ResponseEntity<?> getPetSitterList(
+            @RequestParam(required = false) String status,
+            Pageable pageable) {
+
+        try {
+            log.info("펫시터 목록 조회: status={}", status);
+
+            // 페이지 사이즈 기본값 설정
+            if (pageable.getPageSize() > 50) {
+                pageable = PageRequest.of(pageable.getPageNumber(), 50, pageable.getSort());
+            }
+
+            Page<PetSitterResponseDto> results;
+            if ("APPROVE".equals(status)) {
+                results = petSitterService.findApprovePetSitter(pageable);
+            } else if ("NONE".equals(status)) {
+                results = petSitterService.findNonePetSitter(pageable);
+            } else {
+                results = petSitterService.findAll(pageable);
+            }
+
+            log.info("펫시터 목록 조회 완료: totalElements={}", results.getTotalElements());
+
+            return ResponseEntity.ok(new CustomResponse("조회 성공", results));
+
+        } catch (Exception e) {
+            log.error("펫시터 목록 조회 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new CustomResponse("펫시터 목록 조회 중 오류가 발생했습니다: " + e.getMessage(), null));
+        }
+    }
+
+    //특정 펫시터의 상세 정보를 조회하는 API
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getPetSitterDetail(@PathVariable Integer id) {
+        try {
+            log.info("펫시터 상세 정보 조회: id={}", id);
+
+            PetSitterResponseDto result = petSitterService.findById(id);
+
+            // 사용자 정보 추가 (닉네임 등)
+            if (result != null) {
+                log.info("펫시터 상세 정보 조회 성공: id={}, nickname={}", id, result.getNickname());
+                return ResponseEntity.ok(new CustomResponse("조회 성공", result));
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new CustomResponse("펫시터 정보를 찾을 수 없습니다.", null));
+            }
+        } catch (IllegalArgumentException e) {
+            log.warn("펫시터 상세 정보 조회 실패 - 유효하지 않은 ID: id={}, message={}", id, e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new CustomResponse(e.getMessage(), null));
+        } catch (Exception e) {
+            log.error("펫시터 상세 정보 조회 오류: id={}", id, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new CustomResponse("펫시터 정보 조회 중 오류가 발생했습니다: " + e.getMessage(), null));
         }
     }
 }

--- a/src/main/java/tf/tailfriend/petsitter/service/PetSitterService.java
+++ b/src/main/java/tf/tailfriend/petsitter/service/PetSitterService.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import tf.tailfriend.file.entity.File;
@@ -52,13 +51,6 @@ public class PetSitterService {
 
     @Autowired
     private EntityManager entityManager;
-
-    //사용자의 현재 펫시터 상태를 확인하는 메소드
-    @Transactional(readOnly = true)
-    public PetSitter.PetSitterStatus checkCurrentStatus(Integer userId) {
-        Optional<PetSitter> petSitter = petSitterDao.findById(userId);
-        return petSitter.map(PetSitter::getStatus).orElse(null);
-    }
 
     //사용자 ID로 펫시터 존재 여부 확인
     @Transactional(readOnly = true)
@@ -223,15 +215,14 @@ public class PetSitterService {
                 petType = petTypeDao.findById(requestDto.getPetTypeId()).orElse(null);
             }
 
-            // 트랜잭션 밖에서 사용자 ID로 펫시터 존재 여부 확인
+            //사용자 ID로 펫시터 존재 여부 확인
             boolean exists = petSitterDao.existsById(requestDto.getUserId());
 
             Integer petTypeId = petType != null ? petType.getId() : null;
             Integer fileId = imageFileEntity.getId();
 
-            // 네이티브 쿼리 실행을 위한 EntityManager 사용
+            //EntityManager 사용
             if (exists) {
-                // 기존 데이터 업데이트 쿼리
                 String updateQuery =
                         "UPDATE pet_sitters SET " +
                                 "age = ?1, " +


### PR DESCRIPTION
## 📢 작업 내용
- [x]  펫시터 조회 API 구현 (조건 검색 및 상태별 목록 조회 추가)

## 🔎 변경 사항
- 승인된 펫시터를 조건별(age, petOwnership, sitterExp, houseType)로 검색하는 API 추가
- 펫시터 상태별 목록 조회 API(/list) 구현 (APPROVE, NONE, 전체)
- 펫시터 상세 조회 API(/petsitter/{id}) 구현
- 페이지 사이즈 제한 로직 추가


## ⛓️ 관련 이슈
Closes #128
