### PR TITLE
[MODIFY] 펫스타 북마크에 deleted 컬럼 필터링 추가

### DIFF
--- a/src/main/java/tf/tailfriend/bookmark/service/BookmarkService.java
+++ b/src/main/java/tf/tailfriend/bookmark/service/BookmarkService.java
@@ -30,7 +30,7 @@ public class BookmarkService {
     //사용자의 펫스타 북마크 목록을 조회
     @Transactional(readOnly = true)
     public List<PetstaBookmarkResponseDto> getPetstaBookmarks(Integer userId) {
-        List<PetstaBookmark> bookmarks = petstaBookmarkDao.findByUserId(userId);
+        List<PetstaBookmark> bookmarks = petstaBookmarkDao.findByUserIdAndNotDeleted(userId);
 
         return bookmarks.stream().map(bookmark -> {
             // 게시물 파일 URL 생성
@@ -44,6 +44,7 @@ public class BookmarkService {
             return PetstaBookmarkResponseDto.fromBookmark(bookmark, fileUrl, userPhotoUrl);
         }).collect(Collectors.toList());
     }
+
 
     // 사용자의 게시글 북마크 목록을 조회
     @Transactional(readOnly = true)

--- a/src/main/java/tf/tailfriend/petsta/repository/PetstaBookmarkDao.java
+++ b/src/main/java/tf/tailfriend/petsta/repository/PetstaBookmarkDao.java
@@ -1,6 +1,8 @@
 package tf.tailfriend.petsta.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import tf.tailfriend.petsta.entity.PetstaBookmark;
 
 import java.util.List;
@@ -12,4 +14,7 @@ public interface PetstaBookmarkDao extends JpaRepository<PetstaBookmark, Integer
     boolean existsByUserIdAndPetstaPostId(Integer loginUserId, Integer id);
 
     List<PetstaBookmark> findByUserId(Integer userId);
+
+    @Query("SELECT pb FROM PetstaBookmark pb WHERE pb.user.id = :userId AND pb.petstaPost.deleted = false")
+    List<PetstaBookmark> findByUserIdAndNotDeleted(@Param("userId") Integer userId);
 }


### PR DESCRIPTION
## 📢 작업 내용
- [x] PetstaBookmarkDao에 findByUserIdAndNotDeleted 메서드 추가
- [x] BookmarkService에서 삭제된 게시물 필터링 로직 적용

## 🔎 변경 사항
펫스타 게시물의 deleted 컬럼이 추가됨에 따라, 북마크 기능에서 삭제된 게시물을 제외하고 표시하도록 기능 추가


## ⛓️ 관련 이슈
Closes #131 
