### PR TITLE
[MODIFY] 일반 URL 대신 Presigned URL 사용하도록 수정

### DIFF
--- a/src/main/java/tf/tailfriend/pet/service/PetService.java
+++ b/src/main/java/tf/tailfriend/pet/service/PetService.java
@@ -165,7 +165,7 @@ public class PetService {
 
     private void setPublicUrls(List<PetPhotoDto> photoDtos) {
         for (PetPhotoDto dto : photoDtos) {
-            dto.setPath(fileService.getFullUrl(dto.getPath()));
+            dto.setPath(storageService.generatePresignedUrl(dto.getPath()));
         }
     }
 


### PR DESCRIPTION
## 📢 작업 내용
- [x] 백엔드에서 이미지 URL을 반환할 때 일반 URL 대신 Presigned URL 사용하도록 수정
 
## 🔎 변경 사항
 - PetService.java의 setPublicUrls 메소드를 수정하여 storageService.generatePresignedUrl 메소드 사용


