### PR TITLE
[MODIFY] 회원탈퇴 외래키 삭제 

### DIFF
--- a/src/main/java/tf/tailfriend/board/dto/CommentResponseDto.java
+++ b/src/main/java/tf/tailfriend/board/dto/CommentResponseDto.java
@@ -32,7 +32,7 @@ public class CommentResponseDto {
                 .authorId(comment.getUser().getId())
                 .authorNickname(comment.getUser().getNickname())
                 .authorProfileImg(comment.getUser().getFile().getPath())
-                .content(comment.getContent())
+                .content(comment.isDeleted() ? "삭제된 댓글입니다" : comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .modified(comment.isModified())
                 .deleted(comment.isDeleted())
@@ -41,7 +41,6 @@ public class CommentResponseDto {
                         .map(CommentResponseDto::fromEntity)
                         .toList())
                 .refComment(comment.getRefComment() != null ? CommentSummaryDto.fromEntity(comment.getRefComment()) : null)
-
                 .build();
     }
 

--- a/src/main/java/tf/tailfriend/board/entity/Comment.java
+++ b/src/main/java/tf/tailfriend/board/entity/Comment.java
@@ -61,7 +61,7 @@ public class Comment {
     }
 
     public void setDeleted() {
-        this.content = "";
+        this.content = "삭제된 댓글입니다";
         this.deleted = true;
     }
 

--- a/src/main/java/tf/tailfriend/board/repository/CommentDao.java
+++ b/src/main/java/tf/tailfriend/board/repository/CommentDao.java
@@ -28,5 +28,15 @@ public interface CommentDao extends JpaRepository<Comment, Integer> {
     @Query("DELETE FROM Comment c WHERE c.user.id = :userId")
     void deleteByUserId(@Param("userId") Integer userId);
 
+    @Modifying
+    @Query("UPDATE Comment c SET c.refComment = NULL WHERE c.user.id = :userId OR c.refComment.id IN (SELECT c2.id FROM Comment c2 WHERE c2.user.id = :userId)")
+    void clearRefCommentIdByUser(@Param("userId") Integer userId);
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.parent.id IN (SELECT c2.id FROM Comment c2 WHERE c2.user.id = :userId)")
+    void deleteChildCommentsByParentUserId(@Param("userId") Integer userId);
+    @Modifying
+    @Query(value = "?1", nativeQuery = true)
+    void executeNativeQuery(String sql, Object... params);
     List<Comment> findRepliesByParentId(Integer parentId);
 }

--- a/src/main/java/tf/tailfriend/petsta/repository/PetstaCommentDao.java
+++ b/src/main/java/tf/tailfriend/petsta/repository/PetstaCommentDao.java
@@ -35,5 +35,9 @@ public interface PetstaCommentDao extends JpaRepository<PetstaComment, Integer> 
     @Modifying
     @Query("DELETE FROM PetstaComment pc WHERE pc.user.id = :userId")
     void deleteByUserId(@Param("userId") Integer userId);
+
+    @Modifying
+    @Query(value = "?1", nativeQuery = true)
+    void executeNativeQuery(String sql, Object... params);
 }
 


### PR DESCRIPTION
## 📢 작업 내용
- [x]  회원 탈퇴 시 댓글 삭제 구현 ('삭제된 댓글입니다' 표시)
- [x] 외래 키 제약 조건 위반 문제 해결

## 🔎 변경 사항
- 댓글 소유권 이전 및 소프트 삭제 방식 적용-id1은 탈퇴한 회원입니다라고 할꺼임 ㅇㅇ..
- EntityManager를 이용한 네이티브 쿼리 실행으로 계층형 댓글 구조 처리



## ⛓️ 관련 이슈
Closes #169 
