### PR TITLE
[MODIFY] 회원탈퇴 외래키 제약조건 문제 해결

### DIFF
--- a/src/main/java/tf/tailfriend/petsta/repository/PetstaBookmarkDao.java
+++ b/src/main/java/tf/tailfriend/petsta/repository/PetstaBookmarkDao.java
@@ -22,4 +22,7 @@ public interface PetstaBookmarkDao extends JpaRepository<PetstaBookmark, Integer
     @Modifying
     @Query("DELETE FROM PetstaBookmark pb WHERE pb.user.id = :userId")
     void deleteByUserId(@Param("userId") Integer userId);
+
+    @Query("SELECT pb FROM PetstaBookmark pb JOIN pb.petstaPost p JOIN p.user u WHERE pb.user.id = :userId AND u.deleted = false")
+    List<PetstaBookmark> findByUserIdAndPetstaPostUserNotDeleted(@Param("userId") Integer userId);
 }

--- a/src/main/java/tf/tailfriend/user/entity/User.java
+++ b/src/main/java/tf/tailfriend/user/entity/User.java
@@ -42,6 +42,10 @@ public class User {
     @Column(name = "dong_name")
     private String dongName;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean deleted = false;
+
     private Double latitude;
 
     private Double longitude;
@@ -102,5 +106,20 @@ public class User {
 
     public void updateProfileImage(File file) {
         this.file = file;
+    }
+
+    public void markAsDeleted() {
+        this.deleted = true;
+    }
+
+    public void anonymizeUserData() {
+        this.nickname = "탈퇴한 회원입니다";
+        this.snsAccountId = "deleted_" + System.currentTimeMillis();
+        this.address = null;
+        this.dongName = null;
+        this.latitude = null;
+        this.longitude = null;
+        this.distance = null;
+        this.deleted = true;
     }
 }

--- a/src/main/java/tf/tailfriend/user/entity/UserFollow.java
+++ b/src/main/java/tf/tailfriend/user/entity/UserFollow.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -13,6 +14,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserFollow {
+
 
     @EmbeddedId
     private UserFollowId id;
@@ -33,6 +35,7 @@ public class UserFollow {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserFollowId implements Serializable {
+
 
         @Column(name = "follower_id")
         private Integer followerId;

--- a/src/main/java/tf/tailfriend/user/repository/UserDao.java
+++ b/src/main/java/tf/tailfriend/user/repository/UserDao.java
@@ -10,8 +10,11 @@ import java.util.Optional;
 
 public interface UserDao extends JpaRepository<User, Integer> {
 
-    Optional<User> findBySnsAccountIdAndSnsTypeId(String snsAccountId, Integer snsTypeId);
-    Optional<User> findByNickname(String nickname);
+    Optional<User> findByIdAndDeletedFalse(Integer id);
+    Optional<User> findBySnsAccountIdAndSnsTypeIdAndDeletedFalse(String snsAccountId, Integer snsTypeId);
+    Optional<User> findByNicknameAndDeletedFalse(String nickname);
+
+    boolean existsByNicknameAndDeletedFalse(String nickname);
 
     @Modifying
     @Query("update User u set u.postCount = u.postCount + 1 where u.id = :id")

--- a/src/main/java/tf/tailfriend/user/repository/UserFollowDao.java
+++ b/src/main/java/tf/tailfriend/user/repository/UserFollowDao.java
@@ -15,6 +15,8 @@ public interface UserFollowDao extends JpaRepository<UserFollow, Integer> {
     Optional<UserFollow> findByFollowerIdAndFollowedId(Integer followerId, Integer followedId);
     boolean existsByFollowerIdAndFollowedId(Integer followerId, Integer followedId);
 
+
+
     @Modifying
     @Query("DELETE FROM UserFollow uf WHERE uf.follower.id = :followerId")
     void deleteByFollowerId(@Param("followerId") Integer followerId);
@@ -26,6 +28,7 @@ public interface UserFollowDao extends JpaRepository<UserFollow, Integer> {
     // UserFollowDao.java
     @Query("SELECT uf.followed FROM UserFollow uf WHERE uf.follower.id = :followerId")
     List<User> findTop10ByFollowerId(@Param("followerId") Integer followerId, Pageable pageable);
+
 
 
     List<UserFollow> findByFollowerIdAndFollowedIdIn(Integer currentUserId, List<Integer> collect);

--- a/src/main/java/tf/tailfriend/user/service/AuthService.java
+++ b/src/main/java/tf/tailfriend/user/service/AuthService.java
@@ -64,7 +64,7 @@ public class AuthService {
     }
 
     public Integer getUserIdBySnsAccountIdAndSnsTypeId(String snsAccountId, Integer snsTypeId) {
-        return userDao.findBySnsAccountIdAndSnsTypeId(snsAccountId,snsTypeId)
+        return userDao.findBySnsAccountIdAndSnsTypeIdAndDeletedFalse(snsAccountId, snsTypeId)
                 .map(User::getId)
                 .orElse(null);
     }


### PR DESCRIPTION
## 📢 작업 내용
- [x] 회원탈퇴 외래키 제약조건 문제 해결

## 🔎 변경 사항
- users테이블에 delete 추가했음
- 작성한 댓글은 "삭제된 댓글입니다"로 변경하고 시스템 계정으로 소유권 이전
- 회원이 작성한 게시글 및 펫스타 게시물은 완전 삭제
- 팅방은 그대로 유지하되 사용자 정보만 "탈퇴한 회원"으로 변경
- 각종 카운트(좋아요, 팔로우 등) 조정
- 결제 후 예약 완전히 삭제

