### PR TITLE
[FIX] 예약 상세정보 응답 DTO에 userId 추가

### DIFF
--- a/src/main/java/tf/tailfriend/facility/controller/FacilityController.java
+++ b/src/main/java/tf/tailfriend/facility/controller/FacilityController.java
@@ -3,12 +3,14 @@ package tf.tailfriend.facility.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import tf.tailfriend.facility.dto.FacilityDetailDto;
 import tf.tailfriend.facility.service.FacilityService;
+import tf.tailfriend.global.config.UserPrincipal;
 
 import java.util.Map;
 
@@ -20,8 +22,9 @@ public class FacilityController {
     private final FacilityService facilityService;
 
     @GetMapping("/{id}/detail")
-    public ResponseEntity<?> getFacilityDetailWithReviews(@PathVariable Integer id) {
-        FacilityDetailDto detailDto = facilityService.getFacilityDetailWithReviews(id);
+    public ResponseEntity<?> getFacilityDetailWithReviews(@PathVariable Integer id, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Integer userId = userPrincipal != null ? userPrincipal.getUserId() : null;
+        FacilityDetailDto detailDto = facilityService.getFacilityDetailWithReviews(id, userId);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("data", detailDto));
     }
 

--- a/src/main/java/tf/tailfriend/facility/dto/FacilityDetailDto.java
+++ b/src/main/java/tf/tailfriend/facility/dto/FacilityDetailDto.java
@@ -16,4 +16,5 @@ public class FacilityDetailDto {
     private FacilityResponseDto facility;
     private List<ReviewResponseDto> reviews;
     private List<Object[]> ratingRatio;
+    private Integer userId;
 }

--- a/src/main/java/tf/tailfriend/facility/service/FacilityService.java
+++ b/src/main/java/tf/tailfriend/facility/service/FacilityService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -236,7 +237,7 @@ public class FacilityService {
     }
 
     @Transactional(readOnly = true)
-    public FacilityDetailDto getFacilityDetailWithReviews(Integer facilityId) {
+    public FacilityDetailDto getFacilityDetailWithReviews(Integer facilityId, Integer userId) {
         Facility facility = facilityDao.findById(facilityId)
                 .orElseThrow(() -> new IllegalArgumentException("시설을 찾을 수 없습니다: " + facilityId));
 
@@ -256,7 +257,7 @@ public class FacilityService {
 
         List<Object[]> reviewRatio = reviewDao.countReviewsByStarPoint(facilityId);
 
-        return new FacilityDetailDto(facilityDto, reviewDtos, reviewRatio);
+        return new FacilityDetailDto(facilityDto, reviewDtos, reviewRatio, userId);
     }
 
     private List<ReviewResponseDto> getReviewDtos(Integer facilityId) {


### PR DESCRIPTION
## 📢 작업 내용
- [x] 응답 데이터에 리뷰 작성자 확인용 유저 ID 값 추가

## 🔎 변경 사항
FacilityController, FacilityService 클래스에도 관련 내용 추가

## 🚀 테스트 방법
1. 프론트 axios 요청 후 응답 객체 확인

## 📸 스크린샷 (선택)
![스크린샷 2025-05-09 125731](https://github.com/user-attachments/assets/50f8c31a-e8a8-49d6-b09d-3f97090ab3ab)
